### PR TITLE
Check if the `window.performance` should be used in a duck-typy way

### DIFF
--- a/src/performance.js
+++ b/src/performance.js
@@ -1,11 +1,8 @@
-
-/*global global */
-
 let perf = null, start = Date.now();
 
 // use global browser performance module
 // for node create a polyfill
-if (!global) {
+if (typeof window !== 'undefined' && window.performance) {
   perf = window.performance;
 } else {
   perf = {


### PR DESCRIPTION
In my Rollup setup, there is a fake `global` object that is a reference to `window`, which means that the polyfill (meant for Node.js) will be used instead of `window.performance`.
I'd rather check if `window` exists and has a `performance()` method, and then only use the polyfill if it's not the case.